### PR TITLE
minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Resource usage is calculated by querying the genomics api using operations ids p
 ## Requirements
 * python 2.7
 * pip install --upgrade google-api-python-client
+* pip install --upgrade python-dateutil
 
 ## Usage
 

--- a/calculate.py
+++ b/calculate.py
@@ -48,7 +48,7 @@ class CromwellCostCalculator(object):
             summary_json['tasks'].append({
                     'name': task,
                     'shards': len(task_totals),
-                    'cost_per_shard': self.dollars(sum(task_totals.values())/len(task_totals)),
+                    'cost_per_shard': self.dollars(sum(task_totals.values())/len(task_totals)) if len(task_totals) != 0 else 0,
                     'total_cost': self.dollars(sum(task_totals.values()))
                     })
             max_samples = max(max_samples, len(task_totals))

--- a/calculate.py
+++ b/calculate.py
@@ -40,6 +40,7 @@ class CromwellCostCalculator(object):
         for task, executions in metadata.calls().iteritems():
             task_totals = defaultdict(int)
             for e in executions:
+                if e.jobid() is None: continue
                 op = GenomicsOperation(self.get_operation_metadata(e.jobid()))
                 print 'operation: {}'.format(op)
                 task_totals[e.shard()] = task_totals[e.shard()] + self.dollars(self.calculator.cost(op))

--- a/cromwell.py
+++ b/cromwell.py
@@ -12,7 +12,7 @@ class Execution(object):
         return self.json['shardIndex']
 
     def jobid(self):
-        return self.json['jobId']
+        return self.json.get('jobId', None)
 
     def __str__(self):
         return json.dumps(self.json, sort_keys=True, indent=4, separators=(',', ': '))


### PR DESCRIPTION
* mention the `python-dateutil` prerequisite
* handle cached execution cases
* address a divide-by-zero case when calculating `cost_per_shard`